### PR TITLE
Change DWD OpenData url from HTTPS to HTTP.

### DIFF
--- a/simple_dwd_weatherforecast/dwdforecast.py
+++ b/simple_dwd_weatherforecast/dwdforecast.py
@@ -81,7 +81,7 @@ class Weather:
 
     namespaces = {
         "kml": "http://www.opengis.net/kml/2.2",
-        "dwd": "https://opendata.dwd.de/weather/lib/pointforecast_dwd_extension_V1_0.xsd",
+        "dwd": "http://opendata.dwd.de/weather/lib/pointforecast_dwd_extension_V1_0.xsd",
     }
 
     weather_codes = {


### PR DESCRIPTION
The DWD seems to have missed to update their SSL certificate for https://opendata.dwd.de (08.05.2022 17:27).
The certificate expired at 08.05.2022.

It seems all the requests done by this package contain no data (all GET). So using an unencrypted connection should do no harm. DWD OpenData is completely usable with HTTP.

best regards,
SpiGAndromeda